### PR TITLE
varargs hotfix

### DIFF
--- a/src/main/java/net/jeikobu/jbase/AbstractBot.kt
+++ b/src/main/java/net/jeikobu/jbase/AbstractBot.kt
@@ -10,9 +10,11 @@ import net.jeikobu.jbase.impl.commands.ChangePrefixCommand
 import java.util.*
 import kotlin.reflect.KClass
 
-abstract class AbstractBot(clientBuilder: JDABuilder, configManager: AbstractConfigManager) {
+abstract class AbstractBot(configManager: AbstractConfigManager) {
     protected val defaultCommands: MutableList<KClass<out AbstractCommand>> = Arrays.asList(ChangeLocaleCommand::class, ChangePrefixCommand::class)
     protected val commandManager = CommandManager(configManager)
+    private val clientBuilder = JDABuilder()
+
     val client: JDA
 
     init {

--- a/src/main/java/net/jeikobu/jbase/command/AbstractCommand.kt
+++ b/src/main/java/net/jeikobu/jbase/command/AbstractCommand.kt
@@ -23,7 +23,7 @@ abstract class AbstractCommand(commandData: CommandData) : Localized() {
     fun setVolatile(key: String, value: String) = configManager.volatileStorage.set(destinationGuild, key, value)
 
     fun getLocalized(key: String) = getLocalized(configManager.getLocale(destinationGuild), key)
-    fun getLocalized(key: String, vararg elements: Any) = getLocalized(configManager.getLocale(destinationGuild), key, elements)
+    fun getLocalized(key: String, vararg elements: Any) = getLocalized(configManager.getLocale(destinationGuild), key, *elements)
 
     @Throws(IllegalAccessException::class)
     open fun usageMessage(): String {


### PR DESCRIPTION
- added spread operator to getLocalized in AbstractCommand (lack of it causes issues with localized varargs)
- removed unnecessary clientBuilder constructor argument from AbstractBot